### PR TITLE
Add proxymapping to HttpClientBuilder call

### DIFF
--- a/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
@@ -46,12 +46,26 @@ public class BankidIdentityProvider extends AbstractIdentityProvider<BankidIdent
 		return Response.ok(identity.getToken()).build();
 	}
 
+	public ProxyMappings generateProxyMapping(){
+		String httpsProxy = System.getenv("HTTPS_PROXY");
+		if(httpsProxy == null){
+			httpsProxy = System.getenv("https_proxy");
+		}
+
+		String noProxy = System.getenv("NO_PROXY");
+		if(noProxy == null){
+			noProxy = System.getenv("no_proxy");
+		}
+
+		return ProxyMappings.withFixedProxyMapping(httpsProxy, noProxy);
+	}
+
 	public HttpClient buildBankidHttpClient() {
 
 		try {
 			return (new HttpClientBuilder()).keyStore(getConfig().getKeyStore(), getConfig().getPrivateKeyPassword())
 					.trustStore(getConfig().getTrustStore())
-					.proxyMappings(ProxyMappings.withFixedProxyMapping(System.getenv("HTTPS_PROXY"), ""))
+					.proxyMappings(generateProxyMapping())
 					.build();
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to create BankID HTTP Client", e);

--- a/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
@@ -9,6 +9,7 @@ import org.apache.http.client.HttpClient;
 import org.keycloak.broker.provider.AbstractIdentityProvider;
 import org.keycloak.broker.provider.AuthenticationRequest;
 import org.keycloak.connections.httpclient.HttpClientBuilder;
+import org.keycloak.connections.httpclient.ProxyMappings;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.KeycloakSession;
@@ -49,7 +50,9 @@ public class BankidIdentityProvider extends AbstractIdentityProvider<BankidIdent
 
 		try {
 			return (new HttpClientBuilder()).keyStore(getConfig().getKeyStore(), getConfig().getPrivateKeyPassword())
-					.trustStore(getConfig().getTrustStore()).build();
+					.trustStore(getConfig().getTrustStore())
+					.proxyMappings(ProxyMappings.withFixedProxyMapping(System.getenv("HTTPS_PROXY"), ""))
+					.build();
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to create BankID HTTP Client", e);
 		}


### PR DESCRIPTION
Our keycloak is setup behind a firewall and has no internet access. Internet access is only granted through a proxy server. Since the standard HttpClientBuilder doesn't respect the proxy settings provided by the environment I propose that we add this manually when creating the `HttpClient` by using the `proxyMappings` methods.

Feel free to make any changes or implement this in a nicer way if it is possible.