### PR TITLE
Remove warnings from the Maven shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,28 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<filters>
+					  <filter>
+						<artifact>com.google.zxing:core</artifact>
+						<excludes>
+						  <exclude>META-INF/MANIFEST.MF</exclude>
+						</excludes>
+					  </filter>
+					  <filter>
+						<artifact>com.google.zxing:javase</artifact>
+						<excludes>
+						  <exclude>META-INF/MANIFEST.MF</exclude>
+						</excludes>
+					  </filter>
+					  <filter>
+						<artifact>com.github.jai-imageio:jai-imageio-core</artifact>
+						<excludes>
+						  <exclude>META-INF/MANIFEST.MF</exclude>
+						</excludes>
+					  </filter>
+					</filters>
+				  </configuration>
 			</plugin>
 			<plugin>
 				<groupId>external.atlassian.jgitflow</groupId>

--- a/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
@@ -17,7 +17,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
@@ -37,7 +36,6 @@ import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.IdentityProvider.AuthenticationCallback;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.forms.login.LoginFormsProvider;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import com.google.zxing.BarcodeFormat;

--- a/src/main/java/org/keycloak/broker/bankid/client/SimpleBankidClient.java
+++ b/src/main/java/org/keycloak/broker/bankid/client/SimpleBankidClient.java
@@ -5,10 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.jboss.logging.Logger;
@@ -17,7 +15,6 @@ import org.keycloak.broker.bankid.model.AuthResponse;
 import org.keycloak.broker.bankid.model.BankidHintCodes;
 import org.keycloak.broker.bankid.model.CollectResponse;
 import org.keycloak.broker.bankid.model.Requirements;
-import org.keycloak.models.AuthenticationExecutionModel.Requirement;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.JsonNode;


### PR DESCRIPTION
Remove the warnings printed by the maven shade plugin when building.