### PR TITLE
Update build to version 25 of keycloak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>sweid4keycloak</groupId>
 	<artifactId>bankid4keycloak</artifactId>
-	<version>24.1.0-SNAPSHOT</version>
+	<version>25.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<keycloak.version>24.0.3</keycloak.version>
+		<keycloak.version>25.0.0</keycloak.version>
 		<google.zxing.version>3.4.0</google.zxing.version>
 	</properties>
 	<licenses>

--- a/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
@@ -66,7 +66,7 @@ public class BankidEndpoint {
 		this.config = config;
 		this.callback = callback;
 		this.provider = provider;
-		this.bankidClient = new SimpleBankidClient(provider.buildBankidHttpClient(), config.getApiUrl());
+		this.bankidClient = new SimpleBankidClient(provider.getSession(), config.getApiUrl());
 		InfinispanConnectionProvider infinispanConnectionProvider = provider.getSession()
 				.getProvider(InfinispanConnectionProvider.class);
 		this.actionTokenCache = infinispanConnectionProvider.getCache(InfinispanConnectionProvider.ACTION_TOKEN_CACHE);
@@ -182,9 +182,9 @@ public class BankidEndpoint {
 			AuthenticationSessionModel authSession = this.callback.getAndVerifyAuthenticationSession(state);
 			provider.getSession().getContext().setAuthenticationSession(authSession);
 			BrokeredIdentityContext identity = new BrokeredIdentityContext(
-					getConfig().getAlias().concat("." + getUsername(user)));
+					getConfig().getAlias().concat("." + getUsername(user)),
+					config);
 
-			identity.setIdpConfig(config);
 			identity.setIdp(provider);
 			identity.setUsername(getUsername(user));
 			identity.setFirstName(user.getGivenName());

--- a/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
@@ -59,17 +59,4 @@ public class BankidIdentityProvider extends AbstractIdentityProvider<BankidIdent
 
 		return ProxyMappings.withFixedProxyMapping(httpsProxy, noProxy);
 	}
-
-	public HttpClient buildBankidHttpClient() {
-
-		try {
-			return (new HttpClientBuilder()).keyStore(getConfig().getKeyStore(), getConfig().getPrivateKeyPassword())
-					.trustStore(getConfig().getTrustStore())
-					.proxyMappings(generateProxyMapping())
-					.build();
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to create BankID HTTP Client", e);
-		}
-	}
-
 }

--- a/src/main/java/org/keycloak/broker/bankid/client/SimpleBankidClient.java
+++ b/src/main/java/org/keycloak/broker/bankid/client/SimpleBankidClient.java
@@ -14,6 +14,7 @@ import org.keycloak.broker.bankid.model.Requirements;
 import org.keycloak.broker.provider.util.SimpleHttp;
 import org.keycloak.broker.provider.util.SimpleHttp.Response;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.models.KeycloakSession;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -21,11 +22,11 @@ public class SimpleBankidClient {
 
 	private static final Logger logger = Logger.getLogger(SimpleBankidClient.class);
 
-	private HttpClient bankidHttpClient;
+	private KeycloakSession session;
 	private String baseUrl;
 
-	public SimpleBankidClient(HttpClient bankidHttpClient, String baseUrl) {
-		this.bankidHttpClient = bankidHttpClient;
+	public SimpleBankidClient(KeycloakSession session, String baseUrl) {
+		this.session = session;
 		this.baseUrl = baseUrl;
 	}
 
@@ -80,7 +81,7 @@ public class SimpleBankidClient {
 		try {
 			Response response = SimpleHttp.doPost(
 					this.baseUrl + path,
-					this.bankidHttpClient)
+					this.session)
 					.json(entity)
 					.asResponse();
 			switch (response.getStatus()) {


### PR DESCRIPTION
This updates the build to target version 25.0.0 of keycloak. As part of this, few deprecated method calls were updated in order to build against version 25 of the keycloak API.